### PR TITLE
fix: missing timestamp & expires_in 

### DIFF
--- a/lib/storage/adapter/default.ex
+++ b/lib/storage/adapter/default.ex
@@ -295,14 +295,25 @@ defmodule WeChat.Storage.DefaultHubConnector do
     ])
   end
 
-  defp response_to_access_token({:ok, %{status: 200, body: %{"access_token" => access_token} = body}})
-       when access_token != nil and access_token != "" do
+  defp response_to_access_token(
+         {:ok,
+          %{
+            status: 200,
+            body: %{
+              "access_token" => access_token,
+              "timestamp" => timestamp,
+              "expires_in" => expires_in
+            }
+          }}
+       )
+       when access_token != nil and access_token != "" and
+              is_integer(timestamp) and is_integer(expires_in) do
     {
       :ok,
       %WeChat.Token{
         access_token: access_token,
-        timestamp: Map.get(body, "timestamp"),
-        expires_in: Map.get(body, "expires_in")
+        timestamp: timestamp,
+        expires_in: expires_in
       }
     }
   end
@@ -340,15 +351,23 @@ defmodule WeChat.Storage.DefaultHubConnector do
     }
   end
 
-  defp response_to_ticket({:ok, %{status: 200, body: %{"ticket" => ticket} = body}})
-       when ticket != nil and ticket != "" do
+  defp response_to_ticket(
+         {:ok,
+          %{
+            status: 200,
+            body:
+              %{"ticket" => ticket, "timestamp" => timestamp, "expires_in" => expires_in} = body
+          }}
+       )
+       when ticket != nil and ticket != "" and
+              is_integer(timestamp) and is_integer(expires_in) do
     {
       :ok,
       %WeChat.Ticket{
         value: ticket,
         type: Map.get(body, "type"),
-        timestamp: Map.get(body, "timestamp"),
-        expires_in: Map.get(body, "expires_in")
+        timestamp: timestamp,
+        expires_in: expires_in
       }
     }
   end


### PR DESCRIPTION
fix missing timestamp & expires_in return by call remote_get_component_access_token

## 修复错误

```elixir
** (exit) an exception was raised:
    ** (ArithmeticError) bad argument in arithmetic expression
        :erlang.-(1612768639, nil)
        (elixir_wechat 0.3.3) lib/registry.ex:105: WeChat.Registry.expired?/1
        (elixir_wechat 0.3.3) lib/registry.ex:126: WeChat.Registry.use_cache_if_not_expired/1
        (elixir_wechat 0.3.3) lib/storage/adapter/default.ex:94: WeChat.Storage.Adapter.DefaultComponentClient.fetch_component_access_token/2
        (elixir_wechat 0.3.3) lib/wechat_component.ex:50: WeChat.Component.fetch_component_access_token/2
        (elixir_wechat 0.3.3) lib/http/middleware/component.ex:283: WeChat.Http.Middleware.Component.append_component_access_token/2
```

## 原因分析

当 hub 在收到 `client` 请求的获取 `access_token` 时，如果此时刚好在 `Hub.Token.Keeper` 的还没有刷新该 token

`plug` 会进入 代码分支2的 `remote_get_component_access_token` 去通过微信接口获取最新的 `token`， 此分支的返回值缺失 `timestamp` & `expires_in` 参数

`client` 端也仅仅检查了 `access_token != nil` 的情况，然后存入到 `cache` 之后，在获取的时候获取 `timestamp` 的为 `nil` 值，最后导致上面的报错

## 解决方案

- `remote_get_component_access_token` 分支返回缺失的参数
- `client` 端增加校验缺失值是否存在
