### PR TITLE
fix: hub_client refresh_component_access_token

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -30,6 +30,7 @@ defmodule WeChat.Application do
 
   defp spec_http_client() do
     app = Application.get_application(__MODULE__)
+
     {
       Finch,
       pools: %{
@@ -45,5 +46,4 @@ defmodule WeChat.Application do
   defp spec_registry() do
     WeChat.Registry
   end
-
 end

--- a/lib/http/http.ex
+++ b/lib/http/http.ex
@@ -12,7 +12,8 @@ defmodule WeChat.Http do
   def client(request) do
     Tesla.client(
       [
-        {Tesla.Middleware.Retry, delay: 500, max_retries: 10, should_retry: &match_should_retry?/1},
+        {Tesla.Middleware.Retry,
+         delay: 500, max_retries: 10, should_retry: &match_should_retry?/1},
         {WeChat.Http.Middleware.Common, request}
       ],
       Application.http_adapter()
@@ -23,8 +24,21 @@ defmodule WeChat.Http do
   def component_client(request) do
     Tesla.client(
       [
-        {Tesla.Middleware.Retry, delay: 500, max_retries: 10, should_retry: &match_should_retry?/1},
-        {WeChat.Http.Middleware.Component, request},
+        {Tesla.Middleware.Retry,
+         delay: 500, max_retries: 10, should_retry: &match_should_retry?/1},
+        {WeChat.Http.Middleware.Component, request}
+      ],
+      Application.http_adapter()
+    )
+  end
+
+  @spec component_client :: term()
+  def component_client do
+    Tesla.client(
+      [
+        {Tesla.Middleware.Retry,
+         delay: 500, max_retries: 10, should_retry: &match_should_retry?/1},
+        Tesla.Middleware.JSON
       ],
       Application.http_adapter()
     )

--- a/lib/plug/fetch_component_access_token.ex
+++ b/lib/plug/fetch_component_access_token.ex
@@ -23,9 +23,7 @@ if Code.ensure_loaded?(Plug) do
 
             {:error, %WeChat.Error{} = error} ->
               Logger.error(
-                "fetch access token occurs an error: #{inspect(error)} with query params: #{
-                  inspect(query_params)
-                }"
+                "fetch access token occurs an error: #{inspect(error)} with query params: #{inspect(query_params)}"
               )
 
               error
@@ -47,10 +45,7 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp fetch(_, _) do
-      {
-        :error,
-        %WeChat.Error{reason: "invalid_request"}
-      }
+      {:error, %WeChat.Error{reason: "invalid_request"}}
     end
   end
 end

--- a/lib/plug/refresh_component_access_token.ex
+++ b/lib/plug/refresh_component_access_token.ex
@@ -1,0 +1,72 @@
+if Code.ensure_loaded?(Plug) do
+  defmodule WeChat.Plug.RefreshComponentAccessToken do
+    @moduledoc false
+
+    use Plug.Builder
+    require Logger
+    alias WeChat.Http
+
+    def call(conn, opts) do
+      conn = conn |> super(opts) |> fetch_query_params()
+      adapter_storage = opts[:adapter_storage]
+      body = conn.body_params
+
+      result =
+        try do
+          case refresh(body, adapter_storage) do
+            {:ok, token} ->
+              %{
+                "access_token" => token.access_token,
+                "expires_in" => token.expires_in,
+                "timestamp" => token.timestamp
+              }
+
+            {:error, %WeChat.Error{} = error} ->
+              Logger.error(
+                "fetch access token occurs an error: #{inspect(error)} with body params: #{inspect(body)}"
+              )
+
+              error
+          end
+        rescue
+          error in WeChat.Error ->
+            error
+        end
+
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(200, Jason.encode!(result))
+      |> halt()
+    end
+
+    defp refresh(%{"appid" => appid, "access_token" => access_token}, adapter_storage) do
+      comp_adapter_storage = adapter_storage[:component]
+      token = WeChat.Component.fetch_component_access_token(appid, comp_adapter_storage)
+
+      with {:ok, %{access_token: ^access_token}} <- token,
+           true <- token_expired?(access_token) do
+        adapter_storage.refresh_component_access_token(appid, access_token, nil)
+      else
+        false -> token
+        _ -> token
+      end
+    end
+
+    defp refresh(_, _) do
+      {:error, %WeChat.Error{reason: "invalid_request"}}
+    end
+
+    defp token_expired?(access_token) do
+      Http.component_client()
+      |> Tesla.post(
+        "https://api.weixin.qq.com/cgi-bin/openapi/quota/get",
+        %{"cgi_path" => "/cgi-bin/message/custom/send"},
+        query: [access_token: access_token]
+      )
+      |> case do
+        {:ok, %{status: 200, body: %{"errcode" => 42001}}} -> true
+        _ -> false
+      end
+    end
+  end
+end

--- a/lib/plug/refresh_component_access_token.ex
+++ b/lib/plug/refresh_component_access_token.ex
@@ -13,7 +13,7 @@ if Code.ensure_loaded?(Plug) do
 
       result =
         try do
-          case refresh(body, adapter_storage) do
+          case refresh_if_expired(body, adapter_storage) do
             {:ok, token} ->
               %{
                 "access_token" => token.access_token,
@@ -39,7 +39,7 @@ if Code.ensure_loaded?(Plug) do
       |> halt()
     end
 
-    defp refresh(%{"appid" => appid, "access_token" => access_token}, adapter_storage) do
+    defp refresh_if_expired(%{"appid" => appid, "access_token" => access_token}, adapter_storage) do
       comp_adapter_storage = adapter_storage[:component]
       token = WeChat.Component.fetch_component_access_token(appid, comp_adapter_storage)
 
@@ -52,7 +52,7 @@ if Code.ensure_loaded?(Plug) do
       end
     end
 
-    defp refresh(_, _) do
+    defp refresh_if_expired(_, _) do
       {:error, %WeChat.Error{reason: "invalid_request"}}
     end
 

--- a/lib/plug/refresh_component_access_token.ex
+++ b/lib/plug/refresh_component_access_token.ex
@@ -64,6 +64,7 @@ if Code.ensure_loaded?(Plug) do
         query: [access_token: access_token]
       )
       |> case do
+        {:ok, %{status: 200, body: %{"errcode" => 40001}}} -> true
         {:ok, %{status: 200, body: %{"errcode" => 42001}}} -> true
         _ -> false
       end

--- a/lib/plug/router.ex
+++ b/lib/plug/router.ex
@@ -3,13 +3,17 @@ if Code.ensure_loaded?(Plug) do
     @moduledoc false
 
     use Plug.Router
-
-    alias WeChat.Plug.{FetchAccessToken, RefreshAccessToken, FetchComponentAccessToken, FetchTicket}
-
     alias WeChat.Url
 
-    plug(:match)
+    alias WeChat.Plug.{
+      FetchAccessToken,
+      RefreshAccessToken,
+      FetchComponentAccessToken,
+      RefreshComponentAccessToken,
+      FetchTicket
+    }
 
+    plug(:match)
     plug(:dispatch, builder_opts())
 
     get Url.to_fetch_access_token() do
@@ -22,6 +26,10 @@ if Code.ensure_loaded?(Plug) do
 
     get Url.to_fetch_component_access_token() do
       Plug.run(conn, [{FetchComponentAccessToken, opts}])
+    end
+
+    post Url.to_refresh_component_access_token() do
+      Plug.run(conn, [{RefreshComponentAccessToken, opts}])
     end
 
     get Url.to_fetch_ticket() do

--- a/lib/storage/adapter/default.ex
+++ b/lib/storage/adapter/default.ex
@@ -188,6 +188,11 @@ defmodule WeChat.Storage.Adapter.DefaultComponentClient do
   end
 
   @impl true
+  def refresh_component_access_token(appid, component_access_token, hub_base_url) do
+    Connector.refresh_component_access_token(appid, component_access_token, hub_base_url)
+  end
+
+  @impl true
   @decorate cache()
   def fetch_ticket(appid, authorizer_appid, type, hub_base_url) do
     # Currently, `type` supports "jsapi" | "wx_card"
@@ -204,9 +209,7 @@ defmodule WeChat.Storage.DefaultHubConnector do
 
   def refresh_access_token(appid, access_token, hub_base_url) do
     Logger.info(
-      "send refresh_token request to WeChat hub for appid: #{inspect(appid)}, access_token: #{
-        inspect(access_token)
-      }"
+      "send refresh_token request to WeChat hub for appid: #{inspect(appid)}, access_token: #{inspect(access_token)}"
     )
 
     token =
@@ -224,9 +227,7 @@ defmodule WeChat.Storage.DefaultHubConnector do
 
   def refresh_access_token(appid, authorizer_appid, access_token, hub_base_url) do
     Logger.info(
-      "send refresh_token request to WeChat hub for appid: #{inspect(appid)} with authorizer_appid: #{
-        inspect(authorizer_appid)
-      }, access_token: #{inspect(access_token)}"
+      "send refresh_token request to WeChat hub for appid: #{inspect(appid)} with authorizer_appid: #{inspect(authorizer_appid)}, access_token: #{inspect(access_token)}"
     )
 
     token =
@@ -240,9 +241,7 @@ defmodule WeChat.Storage.DefaultHubConnector do
       |> response_to_access_token()
 
     Logger.info(
-      "received access token from WeChat hub: #{inspect(token)} for appid: #{inspect(appid)} with authorizer_appid: #{
-        inspect(authorizer_appid)
-      }"
+      "received access token from WeChat hub: #{inspect(token)} for appid: #{inspect(appid)} with authorizer_appid: #{inspect(authorizer_appid)}"
     )
 
     token
@@ -268,6 +267,16 @@ defmodule WeChat.Storage.DefaultHubConnector do
     hub_base_url
     |> client()
     |> Tesla.get(Url.to_fetch_component_access_token(), query: [appid: appid])
+    |> response_to_access_token()
+  end
+
+  def refresh_component_access_token(appid, access_token, hub_base_url) do
+    hub_base_url
+    |> client()
+    |> Tesla.post(
+      Url.to_refresh_component_access_token(),
+      %{appid: appid, access_token: access_token}
+    )
     |> response_to_access_token()
   end
 

--- a/lib/storage/adapter/default.ex
+++ b/lib/storage/adapter/default.ex
@@ -188,6 +188,7 @@ defmodule WeChat.Storage.Adapter.DefaultComponentClient do
   end
 
   @impl true
+  @decorate cache()
   def refresh_component_access_token(appid, component_access_token, hub_base_url) do
     Connector.refresh_component_access_token(appid, component_access_token, hub_base_url)
   end

--- a/lib/storage/client.ex
+++ b/lib/storage/client.ex
@@ -112,6 +112,12 @@ defmodule WeChat.Storage.ComponentClient do
         end
 
         @impl true
+        def refresh_component_access_token(appid, component_access_token, args) do
+          access_token = "Refresh component access_token by component appid from your persistence..."
+          {:ok, %WeChat.Token{access_token: access_token}}
+        end
+
+        @impl true
         def fetch_ticket(appid, type, args) do
           ticket = "Get jsapi-ticket/card-ticket from your persistence..."
           {:ok, ticket}
@@ -163,6 +169,16 @@ defmodule WeChat.Storage.ComponentClient do
               appid :: String.t(),
               authorizer_appid :: String.t(),
               access_token :: String.t(),
+              args :: term()
+            ) :: {:ok, %WeChat.Token{}} | {:error, %WeChat.Error{}}
+
+
+  @doc """
+  Refresh access_token of WeChat component application.
+  """
+  @callback refresh_component_access_token(
+              appid :: String.t(),
+              component_access_token :: String.t(),
               args :: term()
             ) :: {:ok, %WeChat.Token{}} | {:error, %WeChat.Error{}}
 

--- a/lib/url.ex
+++ b/lib/url.ex
@@ -1,19 +1,9 @@
 defmodule WeChat.Url do
   @moduledoc false
 
-  def to_refresh_access_token() do
-    "/refresh/access_token"
-  end
-
-  def to_fetch_access_token() do
-    "/client/access_token"
-  end
-
-  def to_fetch_component_access_token() do
-    "/client/component_access_token"
-  end
-
-  def to_fetch_ticket() do
-    "/client/ticket"
-  end
+  def to_refresh_access_token, do: "/refresh/access_token"
+  def to_fetch_access_token, do: "/client/access_token"
+  def to_fetch_component_access_token, do: "/client/component_access_token"
+  def to_refresh_component_access_token, do: "/client/refresh_component_access_token"
+  def to_fetch_ticket, do: "/client/ticket"
 end


### PR DESCRIPTION
notice hub to refresh_component_access_token when hub_client token expired.

In special scenarios, the component_access_token may expire prematurely, 
but the hub fails to handle it in time. 

Therefore, a mechanism is added to let the hub_client role notify the hub to determine whether it has timed out after the hub receives the request. 
If it has timed out, it will be refreshed and return the latest token.